### PR TITLE
Added clean-up step to auto-formatter CICD job

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -37,3 +37,6 @@ jobs:
               working-directory: ./a-life-challenge
               run: git push origin ${GITHUB_REF##*/} || echo
               shell: bash
+            - name: clean up working directory
+              run: rm -f -r a-life-challenge
+              shell: bash


### PR DESCRIPTION
Added a step to the auto-formatter job to remove the cloned git directory after every run. This way we can ensure that the job will run on a fresh copy every time.