### PR TITLE
Animations be zooming

### DIFF
--- a/frontend/src/Animation.js
+++ b/frontend/src/Animation.js
@@ -504,7 +504,7 @@ class Animation extends React.Component {
 
     }
 
-    runQuickAnimations(){
+    runQuickAnimation(){
         let jsx = []
 
         for (let i = 0; i < this.props.creaturesToAnimate.length; i++) {
@@ -538,38 +538,26 @@ class Animation extends React.Component {
         //returns the jsx will all its animations, and the elements in the element array for those animations to reference
         //we only want to actually display the full animation jsx if the time is slow enough to be stable
         let jsx = []
+        this.elementManagement() //manage the elements
 
-        if(this.props.simulationSpeed < 3){
-            // run the full animations
-            this.elementManagement() //manage the elements
+        if(this.props.simulationSpeed < 4){
+            // run the full animations at 1, 2, 3 ticks a second
             jsx = this.runFullAnimations()
-            return (
-                <div id="animation-wrapper">
-                    {jsx}
-                    {elementsArray.map((element) => (
-                        <div key={'map' + keyId++}>{element.elem}</div>
-                    ))}
-                </div>
-            )
 
         } else {
-            //we only animate a speed up movement
-            //first we need to determine the speed, we want the zooming animations to run 2 ticks a second
-            // number of ticks to skip = (ticks per second / 2)
-
-                //run the zoom movement animations
-                this.elementManagement() //manage the elements
-                jsx = this.runQuickAnimations()
-                return (
-                    <div id="animation-wrapper">
-                        {jsx}
-                        {elementsArray.map((element) => (
-                            <div key={'map' + keyId++}>{element.elem}</div>
-                        ))}
-                    </div>
-                )
+            //we only animate movement
+            jsx = this.runQuickAnimation()
             
         }
+
+        return (
+            <div id="animation-wrapper">
+                {jsx}
+                {elementsArray.map((element) => (
+                    <div key={'map' + keyId++}>{element.elem}</div>
+                ))}
+            </div>
+        )
 
     }
 

--- a/frontend/src/Animation.js
+++ b/frontend/src/Animation.js
@@ -388,13 +388,12 @@ class Animation extends React.Component {
         )
     }
 
-    displayText(){
+    runAnimations(){
+        //This function is where the element management and animation magic happen
+        //That way the actual render() function is a bit clearer
+        //While it manages the elements, it only actually returns the animation jsx
 
-    }
-
-    render() {
         let jsx = []
-        let textJsx = []
 
         removeLogArray.forEach((removing) => {
             elementsArray = elementsArray.filter(
@@ -478,16 +477,49 @@ class Animation extends React.Component {
                 </div>
             )
         }
-        //returns the jsx will all its animations, and the elements in the element array for those animations to reference
+
         return (
             <div id="animation-wrapper">
                 {jsx}
+            </div>
+        )
+
+    }
+
+    displayText(){
+
+    }
+
+    render() {
+
+        //returns the jsx will all its animations, and the elements in the element array for those animations to reference
+        let jsx = this.runAnimations()
+
+        //we only want to actually display the jsx if the time is slow enough to be stable
+        //we always want to return the elementsArray
+
+        if(this.props.simulationSpeed < 4){
+            // run the animations
+            return (
+                <div id="animation-wrapper">
+                    {jsx}
+                    {elementsArray.map((element) => (
+                        <div key={'map' + keyId++}>{element.elem}</div>
+                    ))}
+                </div>
+            )
+        }
+
+        return (
+            // just show the elements
+            <div id="animation-wrapper">
                 {elementsArray.map((element) => (
                     <div key={'map' + keyId++}>{element.elem}</div>
                 ))}
             </div>
         )
     }
+
 }
 
 export default Animation

--- a/frontend/src/Animation.js
+++ b/frontend/src/Animation.js
@@ -86,7 +86,7 @@ class Animation extends React.Component {
                             scale: [0, 1],
                             rotate: 360,
                             easing: 'linear',
-                            duration: 1000 / this.props.simulationSpeed
+                            duration: 1000 / this.props.simulationSpeed,
                         },
                     ]}></Anime>
             </>
@@ -103,7 +103,7 @@ class Animation extends React.Component {
                             targets: '#' + creature.creatureId,
                             opacity: '0',
                             easing: 'easeInOutElastic(8, 1)',
-                            duration: 1000 / this.props.simulationSpeed
+                            duration: 1000 / this.props.simulationSpeed,
                         },
                     ]}></Anime>
             </>
@@ -122,52 +122,72 @@ class Animation extends React.Component {
                                 {
                                     translateY: '-=2vh',
                                     easing: 'linear',
-                                    duration: 1000/(10*this.props.simulationSpeed)  
+                                    duration:
+                                        1000 /
+                                        (10 * this.props.simulationSpeed),
                                 },
                                 {
                                     translateY: '-=0.6vh',
                                     easing: 'linear',
-                                    duration: 1000/(10*this.props.simulationSpeed)
+                                    duration:
+                                        1000 /
+                                        (10 * this.props.simulationSpeed),
                                 },
                                 {
                                     translateY: '+=0.1vh',
                                     easing: 'linear',
-                                    duration: 1000/(10*this.props.simulationSpeed) 
+                                    duration:
+                                        1000 /
+                                        (10 * this.props.simulationSpeed),
                                 },
                                 {
                                     translateY: '+=0.5vh',
                                     easing: 'linear',
-                                    duration: 1000/(10*this.props.simulationSpeed) 
+                                    duration:
+                                        1000 /
+                                        (10 * this.props.simulationSpeed),
                                 },
                                 {
                                     translateY: '+=2vh',
                                     easing: 'linear',
-                                    duration: 1000/(10*this.props.simulationSpeed) 
+                                    duration:
+                                        1000 /
+                                        (10 * this.props.simulationSpeed),
                                 },
                                 {
                                     translateY: '-=2vh',
                                     easing: 'linear',
-                                    duration: 1000/(10*this.props.simulationSpeed) 
+                                    duration:
+                                        1000 /
+                                        (10 * this.props.simulationSpeed),
                                 },
                                 {
                                     translateY: '-=0.6vh',
                                     easing: 'linear',
-                                    duration: 1000/(10*this.props.simulationSpeed) 
+                                    duration:
+                                        1000 /
+                                        (10 * this.props.simulationSpeed),
                                 },
                                 {
                                     translateY: '+=0.1vh',
                                     easing: 'linear',
-                                    duration: 1000/(10*this.props.simulationSpeed) 
+                                    duration:
+                                        1000 /
+                                        (10 * this.props.simulationSpeed),
                                 },
                                 {
                                     translateY: '+=0.5vh',
                                     easing: 'linear',
-                                    duration: 1000/(10*this.props.simulationSpeed) 
+                                    duration:
+                                        1000 /
+                                        (10 * this.props.simulationSpeed),
                                 },
                                 {
                                     translateY: '+=2vh',
                                     easing: 'linear',
-                                    duration: 1000/(10*this.props.simulationSpeed) 
+                                    duration:
+                                        1000 /
+                                        (10 * this.props.simulationSpeed),
                                 },
                             ],
                         },
@@ -185,14 +205,20 @@ class Animation extends React.Component {
                         {
                             targets: '#' + creature.creatureId,
                             keyframes: [
-                                { opacity: '0.2',
-                                  duration: 1000/(3*this.props.simulationSpeed)  
+                                {
+                                    opacity: '0.2',
+                                    duration:
+                                        1000 / (3 * this.props.simulationSpeed),
                                 },
-                                { opacity: '0.2', 
-                                  duration: 1000/(3*this.props.simulationSpeed)  
+                                {
+                                    opacity: '0.2',
+                                    duration:
+                                        1000 / (3 * this.props.simulationSpeed),
                                 },
-                                { opacity: '1',
-                                  duration: 1000/(3*this.props.simulationSpeed)  
+                                {
+                                    opacity: '1',
+                                    duration:
+                                        1000 / (3 * this.props.simulationSpeed),
                                 },
                             ],
                             easing: 'linear',
@@ -220,7 +246,6 @@ class Animation extends React.Component {
         )
     }
 
-
     AnimateMaturing(creature) {
         // animates a creature maturing, sizes up then back down again
         return (
@@ -233,17 +258,20 @@ class Animation extends React.Component {
                                 {
                                     scale: [1, 1.1],
                                     easing: 'easeInOutElastic(2, 2)',
-                                    duration: 1000 / (3*this.props.simulationSpeed)
+                                    duration:
+                                        1000 / (3 * this.props.simulationSpeed),
                                 },
                                 {
                                     scale: [1, 1.5],
                                     easing: 'easeInOutElastic(4, 2)',
-                                    duration: 1000 / (3*this.props.simulationSpeed)
+                                    duration:
+                                        1000 / (3 * this.props.simulationSpeed),
                                 },
                                 {
                                     scale: [1.5, 1],
                                     easing: 'linear',
-                                    duration: 1000 / (3*this.props.simulationSpeed)
+                                    duration:
+                                        1000 / (3 * this.props.simulationSpeed),
                                 },
                             ],
                         },
@@ -264,12 +292,14 @@ class Animation extends React.Component {
                                 {
                                     translateX: '+=0.5vw',
                                     easing: 'easeInOutElastic(7, 1)',
-                                    duration: 1000 / (2*this.props.simulationSpeed)
+                                    duration:
+                                        1000 / (2 * this.props.simulationSpeed),
                                 },
                                 {
                                     translateX: '-=0.5vw',
                                     easing: 'linear',
-                                    duration: 1000 / (2*this.props.simulationSpeed)
+                                    duration:
+                                        1000 / (2 * this.props.simulationSpeed),
                                 },
                             ],
                         },
@@ -291,7 +321,6 @@ class Animation extends React.Component {
                                     scale: [1, 0.5],
                                     opacity: '0.5',
                                     easing: 'easeInOutElastic(4, 1.5)',
-                                    
                                 },
                                 {
                                     scale: [0.5, 1],
@@ -390,11 +419,11 @@ class Animation extends React.Component {
         )
     }
 
-    elementManagement(){
+    elementManagement() {
         //adds, removes, and re-add elements at their new locations
         //this has to happen regardless of whether the animations are running, as we still
         //want the creatures to at least Show on screen
-        
+
         removeLogArray.forEach((removing) => {
             elementsArray = elementsArray.filter(
                 (element) => element.key !== removing.key
@@ -430,7 +459,7 @@ class Animation extends React.Component {
             } else if (creature.lastAction === 'DEATH') {
                 //remove the element After playing the animation
                 removeLogArray.push({ key: creature.creatureId })
-            } 
+            }
             //move the creatures
             changeLogArray.push({
                 key: creature.creatureId,
@@ -441,10 +470,9 @@ class Animation extends React.Component {
                 ),
             })
         }
-
     }
 
-    runFullAnimations(){
+    runFullAnimations() {
         //This function is where the animation magic happens
         //That way the actual render() function is a bit clearer
         //returns the full animation jsx
@@ -479,12 +507,11 @@ class Animation extends React.Component {
                 jsx.push(
                     <div key={keyId++}>{this.AnimateMaturing(creature)}</div>
                 )
-            } 
+            }
 
             //move the creatures
             jsx.push(<div key={keyId++}>{this.AnimateMovement(creature)}</div>)
         }
-        
 
         for (let i = 0; i < this.props.resourcesToAnimate.length; i++) {
             let resource = this.props.resourcesToAnimate[i]
@@ -496,15 +523,10 @@ class Animation extends React.Component {
             )
         }
 
-        return (
-            <div id="animation-wrapper">
-                {jsx}
-            </div>
-        )
-
+        return <div id="animation-wrapper">{jsx}</div>
     }
 
-    runQuickAnimation(){
+    runQuickAnimation() {
         let jsx = []
 
         for (let i = 0; i < this.props.creaturesToAnimate.length; i++) {
@@ -513,7 +535,6 @@ class Animation extends React.Component {
             //move the creatures
             jsx.push(<div key={keyId++}>{this.AnimateMovement(creature)}</div>)
         }
-        
 
         for (let i = 0; i < this.props.resourcesToAnimate.length; i++) {
             let resource = this.props.resourcesToAnimate[i]
@@ -525,29 +546,21 @@ class Animation extends React.Component {
             )
         }
 
-        return (
-            <div id="animation-wrapper">
-                {jsx}
-            </div>
-        )
+        return <div id="animation-wrapper">{jsx}</div>
     }
 
-
     render() {
-
         //returns the jsx will all its animations, and the elements in the element array for those animations to reference
         //we only want to actually display the full animation jsx if the time is slow enough to be stable
         let jsx = []
         this.elementManagement() //manage the elements
 
-        if(this.props.simulationSpeed < 4){
+        if (this.props.simulationSpeed < 4) {
             // run the full animations at 1, 2, 3 ticks a second
             jsx = this.runFullAnimations()
-
         } else {
             //we only animate movement
             jsx = this.runQuickAnimation()
-            
         }
 
         return (
@@ -558,9 +571,7 @@ class Animation extends React.Component {
                 ))}
             </div>
         )
-
     }
-
 }
 
 export default Animation

--- a/frontend/src/Animation.js
+++ b/frontend/src/Animation.js
@@ -1,6 +1,5 @@
 import './DummyConnection.css'
 import React from 'react'
-import axios from 'axios'
 import ReactAnime from 'react-animejs'
 
 const { Anime } = ReactAnime
@@ -22,7 +21,6 @@ class Animation extends React.Component {
         }
         this.AnimateBirth = this.AnimateBirth.bind(this)
         this.AnimateMovement = this.AnimateMovement.bind(this)
-        this.getCreatureInfo = this.getCreatureInfo.bind(this)
     }
 
     CreateCreature(creature) {
@@ -87,6 +85,7 @@ class Animation extends React.Component {
                             scale: [0, 1],
                             rotate: 360,
                             easing: 'linear',
+                            duration: 1000 / this.props.simulationSpeed
                         },
                     ]}></Anime>
             </>
@@ -102,8 +101,8 @@ class Animation extends React.Component {
                         {
                             targets: '#' + creature.creatureId,
                             opacity: '0',
-                            duration: 3000,
                             easing: 'easeInOutElastic(8, 1)',
+                            duration: 1000 / this.props.simulationSpeed
                         },
                     ]}></Anime>
             </>
@@ -122,42 +121,52 @@ class Animation extends React.Component {
                                 {
                                     translateY: '-=2vh',
                                     easing: 'linear',
+                                    duration: 1000/(10*this.props.simulationSpeed)  
                                 },
                                 {
                                     translateY: '-=0.6vh',
                                     easing: 'linear',
+                                    duration: 1000/(10*this.props.simulationSpeed)
                                 },
                                 {
                                     translateY: '+=0.1vh',
                                     easing: 'linear',
+                                    duration: 1000/(10*this.props.simulationSpeed) 
                                 },
                                 {
                                     translateY: '+=0.5vh',
                                     easing: 'linear',
+                                    duration: 1000/(10*this.props.simulationSpeed) 
                                 },
                                 {
                                     translateY: '+=2vh',
                                     easing: 'linear',
+                                    duration: 1000/(10*this.props.simulationSpeed) 
                                 },
                                 {
                                     translateY: '-=2vh',
                                     easing: 'linear',
+                                    duration: 1000/(10*this.props.simulationSpeed) 
                                 },
                                 {
                                     translateY: '-=0.6vh',
                                     easing: 'linear',
+                                    duration: 1000/(10*this.props.simulationSpeed) 
                                 },
                                 {
                                     translateY: '+=0.1vh',
                                     easing: 'linear',
+                                    duration: 1000/(10*this.props.simulationSpeed) 
                                 },
                                 {
                                     translateY: '+=0.5vh',
                                     easing: 'linear',
+                                    duration: 1000/(10*this.props.simulationSpeed) 
                                 },
                                 {
                                     translateY: '+=2vh',
                                     easing: 'linear',
+                                    duration: 1000/(10*this.props.simulationSpeed) 
                                 },
                             ],
                         },
@@ -175,9 +184,15 @@ class Animation extends React.Component {
                         {
                             targets: '#' + creature.creatureId,
                             keyframes: [
-                                { opacity: '0.2' },
-                                { opacity: '0.2' },
-                                { opacity: '1' },
+                                { opacity: '0.2',
+                                  duration: 1000/(3*this.props.simulationSpeed)  
+                                },
+                                { opacity: '0.2', 
+                                  duration: 1000/(3*this.props.simulationSpeed)  
+                                },
+                                { opacity: '1',
+                                  duration: 1000/(3*this.props.simulationSpeed)  
+                                },
                             ],
                             easing: 'linear',
                         },
@@ -197,6 +212,7 @@ class Animation extends React.Component {
                             left: `${creature.locationX}px`,
                             top: `${creature.locationY}px`,
                             easing: 'linear',
+                            duration: 1000 / this.props.simulationSpeed,
                         },
                     ]}></Anime>
             </>
@@ -215,14 +231,17 @@ class Animation extends React.Component {
                                 {
                                     scale: [1, 1.1],
                                     easing: 'easeInOutElastic(2, 2)',
+                                    duration: 1000 / (3*this.props.simulationSpeed)
                                 },
                                 {
                                     scale: [1, 1.5],
                                     easing: 'easeInOutElastic(4, 2)',
+                                    duration: 1000 / (3*this.props.simulationSpeed)
                                 },
                                 {
                                     scale: [1.5, 1],
                                     easing: 'linear',
+                                    duration: 1000 / (3*this.props.simulationSpeed)
                                 },
                             ],
                         },
@@ -243,10 +262,12 @@ class Animation extends React.Component {
                                 {
                                     translateX: '+=0.5vw',
                                     easing: 'easeInOutElastic(7, 1)',
+                                    duration: 1000 / (2*this.props.simulationSpeed)
                                 },
                                 {
                                     translateX: '-=0.5vw',
                                     easing: 'linear',
+                                    duration: 1000 / (2*this.props.simulationSpeed)
                                 },
                             ],
                         },
@@ -268,6 +289,7 @@ class Animation extends React.Component {
                                     scale: [1, 0.5],
                                     opacity: '0.5',
                                     easing: 'easeInOutElastic(4, 1.5)',
+                                    
                                 },
                                 {
                                     scale: [0.5, 1],
@@ -366,29 +388,14 @@ class Animation extends React.Component {
         )
     }
 
-    getCreatureInfo() {
-        // Use axios to retrieve info from the backend
-        axios({
-            method: 'GET',
-            url: 'http://localhost:5000/get-info',
-        }).then((response) => {
-            const res = response.data
-            // change the state variable to trigger a re-render
-            this.setState({
-                creatureId: res.creatureId,
-                species: res.species,
-                movement: res.movement,
-                birth: res.birth,
-                locationX: res.locationX,
-                locationY: res.locationY,
-                shape: res.shape,
-                color: res.color,
-            })
-        })
+    displayText(){
+
     }
 
     render() {
-        //remove any creatures that were killed
+        let jsx = []
+        let textJsx = []
+
         removeLogArray.forEach((removing) => {
             elementsArray = elementsArray.filter(
                 (element) => element.key !== removing.key
@@ -405,8 +412,8 @@ class Animation extends React.Component {
 
         // now re-add the items that moved from changelog at the correct location
         elementsArray = elementsArray.concat(changeLogArray)
+        console.log(this.props.simulationSpeed)
 
-        let jsx = []
         changeLogArray = [] //reset the movement log
         removeLogArray = []
 
@@ -447,7 +454,7 @@ class Animation extends React.Component {
                 jsx.push(
                     <div key={keyId++}>{this.AnimateMaturing(creature)}</div>
                 )
-            }
+            } 
 
             //move the creatures
             changeLogArray.push({
@@ -460,21 +467,7 @@ class Animation extends React.Component {
             })
             jsx.push(<div key={keyId++}>{this.AnimateMovement(creature)}</div>)
         }
-        //this is the updated format for animating the resources, not going to actually add it until I can
-        //check if it works
-
-        /*for (let i = 0; i < this.props.resourcesToAnimate.length; i++) {
-            let resource = this.props.resourcesToAnimate[i]
-            elementsArray.push({
-                key: creature.creatureId,
-                elem: (
-                    <div key={'creature' + keyId++}>
-                        {this.CreateCreature(creature)}
-                    </div>
-                ),
-            })
-            jsx.push(<div key={'res' + { i }}>{this.AnimateResourceSpawn(resource)}</div>)
-        }*/
+        
 
         for (let i = 0; i < this.props.resourcesToAnimate.length; i++) {
             let resource = this.props.resourcesToAnimate[i]
@@ -485,7 +478,6 @@ class Animation extends React.Component {
                 </div>
             )
         }
-
         //returns the jsx will all its animations, and the elements in the element array for those animations to reference
         return (
             <div id="animation-wrapper">

--- a/frontend/src/Animation.js
+++ b/frontend/src/Animation.js
@@ -15,7 +15,6 @@ let textChangeLogArray = []
 let removeLogArray = []
 let keyId = 0
 
-
 class Animation extends React.Component {
     constructor(props) {
         super(props)
@@ -28,22 +27,20 @@ class Animation extends React.Component {
         this.AnimateMovement = this.AnimateMovement.bind(this)
     }
 
-    CreateText(creature){
+    CreateText(creature) {
         return (
             <div
-                id={"text" + creature.creatureId}
+                id={'text' + creature.creatureId}
                 style={{
                     position: 'absolute',
                     left: `${creature.locationX - textOffsetSide}px`,
                     top: `${creature.locationY - textOffsetUp}px`,
-                    fontSize: "1.5vh",
-                }}
-            >
+                    fontSize: '1.5vh',
+                }}>
                 {creature.creatureId + ': '}
 
                 {creature.lastAction}
             </div>
-            
         )
     }
 
@@ -265,10 +262,10 @@ class Animation extends React.Component {
                             duration: 1000 / this.props.simulationSpeed,
                         },
                     ]}></Anime>
-                                    <Anime
+                <Anime
                     initial={[
                         {
-                            targets: "#text" + creature.creatureId,
+                            targets: '#text' + creature.creatureId,
                             left: `${creature.locationX - textOffsetSide}px`,
                             top: `${creature.locationY - textOffsetUp}px`,
                             easing: 'linear',
@@ -475,9 +472,7 @@ class Animation extends React.Component {
         })
 
         textChangeLogArray.forEach((log) => {
-            textArray = textArray.filter(
-                (element) => element.key !== log.key
-            )
+            textArray = textArray.filter((element) => element.key !== log.key)
         })
 
         // now re-add the items that moved from changelog at the correct location
@@ -512,7 +507,7 @@ class Animation extends React.Component {
             } else if (creature.lastAction === 'DEATH') {
                 //remove the element After playing the animation
                 removeLogArray.push({ key: creature.creatureId })
-                removeLogArray.push({key: "text" + creature.creatureId})
+                removeLogArray.push({ key: 'text' + creature.creatureId })
             }
 
             //move the creatures
@@ -526,7 +521,7 @@ class Animation extends React.Component {
             })
 
             textChangeLogArray.push({
-                key: "text" + creature.creatureId,
+                key: 'text' + creature.creatureId,
                 elem: (
                     <div key={'text' + keyId++}>
                         {this.CreateText(creature)}
@@ -631,10 +626,9 @@ class Animation extends React.Component {
                     ))}
                 </div>
             )
-
         } else {
             //we only animate movement
-            // here we also include the text, this can easily be moved to a different 
+            // here we also include the text, this can easily be moved to a different
             // if statement, so it can be hooked up to a button
             jsx = this.runQuickAnimation()
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -142,6 +142,7 @@ function App() {
                 <Animation
                     creaturesToAnimate={creatureList}
                     resourcesToAnimate={resourceList}
+                    simulationSpeed={simulationTicksPerSecond}
                 />
                 <SimulationNavBar
                     playOrPauseSimulationCallback={playPauseSimulation}


### PR DESCRIPTION
The animations now speed up and slow down based on the simulation speed.
At 4+ tick speeds (this can be easily changed later), the full animations stop but the elements still move around. The amount of teleporting seems to vary by run but I've found this setup to be the most stable. Also at 4+ tick speed, the text shows up above elements. I have it set up so that it can be easily hooked up to a button if we decide to do that instead of it being speed based.

In order to choose what to animate I had to do a lot of refactoring. It is now split up between element management, animation management, and the rendering.

edit: the only change to App.js is sending in the tick speed
