### PR TITLE
Day night cycle updated

### DIFF
--- a/backend/environment.py
+++ b/backend/environment.py
@@ -395,7 +395,7 @@ class Environment:
         if elapsedTicks < 30:
             timeOfSimulation = 'midnight'
         elif elapsedTicks < 60:
-            timeOfSimulation = 'dusk'
+            timeOfSimulation = 'dawn'
         elif elapsedTicks < 130:
             timeOfSimulation = 'early morning'
         elif elapsedTicks < 200:

--- a/backend/environment.py
+++ b/backend/environment.py
@@ -415,21 +415,21 @@ class Environment:
     def getLightVisibility(self):
         elapsedTicks = self.timeOfSimulation % 500
         if elapsedTicks < 30:           # Ticks 0-30, Midnight (early)
-            self.lightVisibility = 0.2  
+            self.lightVisibility = 0.2
         elif elapsedTicks < 60:         # Ticks 30-59, Dawn
-            self.lightVisibility = 0.3  
+            self.lightVisibility = 0.3
         elif elapsedTicks < 130:        # Ticks 60-129, Early Morning
-            self.lightVisibility = 0.5  
+            self.lightVisibility = 0.5
         elif elapsedTicks < 200:        # Ticks 130-199, Late Morning
-            self.lightVisibility = 0.8  
+            self.lightVisibility = 0.8
         elif elapsedTicks < 270:        # Ticks 200-269, Noon
-            self.lightVisibility = 1.0  
+            self.lightVisibility = 1.0
         elif elapsedTicks < 340:        # Ticks 270-339, Afternoon
-            self.lightVisibility = 0.8  
+            self.lightVisibility = 0.8
         elif elapsedTicks < 410:        # Ticks 340-409, Evening
-            self.lightVisibility = 0.5  
-        elif elapsedTicks < 440:        # Ticks 410-439, Dusk 
-            self.lightVisibility = 0.3  
+            self.lightVisibility = 0.5
+        elif elapsedTicks < 440:        # Ticks 410-439, Dusk
+            self.lightVisibility = 0.3
         else:                           # Ticks 440-500, Midnight
-            self.lightVisibility = 0.2  
+            self.lightVisibility = 0.2
         return self.lightVisibility

--- a/backend/environment.py
+++ b/backend/environment.py
@@ -385,39 +385,51 @@ class Environment:
 
         # Check if 300 ticks have elapsed and increment daysElapsed in the
         # simulation if so
-        if self.timeOfSimulation % 300 == 0:
+        if self.timeOfSimulation % 500 == 0:
             self.daysElapsed += 1
 
     def getTimeOfSimulation(self):
-        # A day cycle is currently set to 300, so once ticks reach 300, a new
+        # A day cycle is currently set to 500, so once ticks reach 500, a new
         # day starts
-        elapsedTicks = self.timeOfSimulation % 300
+        elapsedTicks = self.timeOfSimulation % 500
         if elapsedTicks < 30:
-            timeOfSimulation = 'dawn'
-        elif elapsedTicks < 90:
-            timeOfSimulation = 'morning'
-        elif elapsedTicks < 150:
-            timeOfSimulation = 'noon'
-        elif elapsedTicks < 210:
-            timeOfSimulation = 'afternoon'
-        elif elapsedTicks < 270:
-            timeOfSimulation = 'evening'
-        else:
+            timeOfSimulation = 'midnight'
+        elif elapsedTicks < 60:
             timeOfSimulation = 'dusk'
+        elif elapsedTicks < 130:
+            timeOfSimulation = 'early morning'
+        elif elapsedTicks < 200:
+            timeOfSimulation = 'late morning'
+        elif elapsedTicks < 270:
+            timeOfSimulation = 'noon'
+        elif elapsedTicks < 340:
+            timeOfSimulation = 'afternoon'
+        elif elapsedTicks < 410:
+            timeOfSimulation = 'evening'
+        elif elapsedTicks < 440:
+            timeOfSimulation = 'dusk'
+        else:
+            timeOfSimulation = 'midnight'
         return f"{timeOfSimulation}, {elapsedTicks} ticks elapsed, {self.daysElapsed} days elapsed"
 
     def getLightVisibility(self):
-        elapsedTicks = self.timeOfSimulation % 300
-        if elapsedTicks < 30:
-            self.lightVisibility = 0.2  # Low visibility at dawn
-        elif elapsedTicks < 90:
-            self.lightVisibility = 1.0  # Full visibility during morning and noon
-        elif elapsedTicks < 150:
-            self.lightVisibility = 0.8  # Slightly reduced visibility in the afternoon
-        elif elapsedTicks < 210:
-            self.lightVisibility = 0.5  # Reduced visibility in the evening
-        elif elapsedTicks < 270:
-            self.lightVisibility = 0.3  # Low visibility at dusk
-        else:
-            self.lightVisibility = 0.2  # Low visibility at night
+        elapsedTicks = self.timeOfSimulation % 500
+        if elapsedTicks < 30:           # Ticks 0-30, Midnight (early)
+            self.lightVisibility = 0.2  
+        elif elapsedTicks < 60:         # Ticks 30-59, Dawn
+            self.lightVisibility = 0.3  
+        elif elapsedTicks < 130:        # Ticks 60-129, Early Morning
+            self.lightVisibility = 0.5  
+        elif elapsedTicks < 200:        # Ticks 130-199, Late Morning
+            self.lightVisibility = 0.8  
+        elif elapsedTicks < 270:        # Ticks 200-269, Noon
+            self.lightVisibility = 1.0  
+        elif elapsedTicks < 340:        # Ticks 270-339, Afternoon
+            self.lightVisibility = 0.8  
+        elif elapsedTicks < 410:        # Ticks 340-409, Evening
+            self.lightVisibility = 0.5  
+        elif elapsedTicks < 440:        # Ticks 410-439, Dusk 
+            self.lightVisibility = 0.3  
+        else:                           # Ticks 440-500, Midnight
+            self.lightVisibility = 0.2  
         return self.lightVisibility


### PR DESCRIPTION
List of changes made to the day/night cycle:

- Changed the cycle of day progression to every 500 ticks (was 300)
- Changed the cycle to be more gradual as the ticks progress. I essentially took the back half of the cycle and made it symmetrical for the front half. As of now, the cycle of lightVisibility values is as follows: 0.2 -> 0.3 -> 0.5 -> 0.8 -> 1 -> 0.8 -> 0.5 -> 0.3 -> 0.2
- Changed the tick counts to be more accurate to how IRL day/night cycle works. i.e, Night/Midnight lasts the longest, dawn/dusk are short term, then the rest are the same duration. 