### PR TITLE
Refactored relationship between the `Creature` and `DecisionNetwork` Objects

### DIFF
--- a/backend/creatures/creature.py
+++ b/backend/creatures/creature.py
@@ -53,7 +53,7 @@ class Creature:
             loadExistingSave=False,
             saveData=None):
         self._decisionNetwork = decisionNetwork
-        
+
         if not loadExistingSave:
             logging.info(f"Initializing new creature with id {id}")
             self.genome = inputGenome

--- a/backend/creatures/creature.py
+++ b/backend/creatures/creature.py
@@ -49,8 +49,11 @@ class Creature:
             yCoordinate,
             speciesManager,
             environment,
+            decisionNetwork,
             loadExistingSave=False,
             saveData=None):
+        self._decisionNetwork = decisionNetwork
+        
         if not loadExistingSave:
             logging.info(f"Initializing new creature with id {id}")
             self.genome = inputGenome
@@ -66,11 +69,6 @@ class Creature:
 
             self.reproductionCoolDown = 50 * self.genome.reproductionCooldown
             self.hasPerformedActionThisTurn = True
-
-            if self.genome.reproductionType == genome.ReproductionType.ASEXUAL:
-                self._decisionNetwork = decision_network.DecisionNetworkAsexual()
-            else:
-                self._decisionNetwork = decision_network.DecisionNetworkSexual()
 
             self.maxHealth = inputGenome.maxHealth * 100
             self.currentHealth = copy.deepcopy(self.maxHealth)

--- a/backend/creatures/decision_network.py
+++ b/backend/creatures/decision_network.py
@@ -2,7 +2,6 @@ import logging
 from abc import ABCMeta, abstractmethod
 from enum import Enum
 import math
-from . import species_manager
 
 
 logging.basicConfig(

--- a/backend/creatures/species_manager.py
+++ b/backend/creatures/species_manager.py
@@ -30,8 +30,11 @@ class SpeciesManager:
             simulationWidth,
             simulationHeight,
             environment,
+            decisionNetwork,
             loadExistingSave=False,
             saveData=None):
+        self._decisionNetwork = decisionNetwork
+
         if not loadExistingSave:
             logging.info(f"Initializing new Species Manager for {speciesName}")
 
@@ -115,6 +118,7 @@ class SpeciesManager:
                         0,
                         self,
                         self.environment,
+                        self._decisionNetwork,
                         loadExistingSave=True,
                         saveData=savedCreature))
 
@@ -172,7 +176,8 @@ class SpeciesManager:
             newCreatureSpawnX,
             newCreatureSpawnY,
             self,
-            self.environment)
+            self.environment,
+            self._decisionNetwork)
 
         self._creatures.append(newCreature)
 
@@ -203,7 +208,8 @@ class SpeciesManager:
             newCreatureSpawnX,
             newCreatureSpawnY,
             self,
-            self.environment)
+            self.environment,
+            self._decisionNetwork)
 
         self._creatures.append(newCreature)
 

--- a/backend/god.py
+++ b/backend/god.py
@@ -75,8 +75,8 @@ class God:
             self._speciesManagers = []
             for savedSpecies in saveData['_speciesManagers']:
                 decisionNetworkToUse = self._sexualReproductionDecisionNetwork \
-                                        if savedSpecies['_startingGenome'] == 'Sexual' \
-                                        else self._asexualReproductionDecisionNetwork
+                    if savedSpecies['_startingGenome'] == 'Sexual' \
+                    else self._asexualReproductionDecisionNetwork
                 self._speciesManagers.append(
                     creatures.species_manager.SpeciesManager(
                         None,
@@ -134,8 +134,8 @@ class God:
         logging.info(f"Creating new species: {speciesName}")
 
         decisionNetworkToUse = self._sexualReproductionDecisionNetwork \
-                                if startingGenome.reproductionType == ReproductionType.SEXUAL \
-                                else self._asexualReproductionDecisionNetwork
+            if startingGenome.reproductionType == ReproductionType.SEXUAL \
+            else self._asexualReproductionDecisionNetwork
 
         newSpecies = creatures.species_manager.SpeciesManager(
             speciesName,

--- a/backend/god.py
+++ b/backend/god.py
@@ -2,10 +2,8 @@ import logging
 import environment
 import topography
 import creatures.species_manager
-import random
-from environment import Environment
-import time
-import datetime
+from creatures.decision_network import DecisionNetworkSexual, DecisionNetworkAsexual
+from creatures.genome import ReproductionType
 
 logging.basicConfig(
     level=logging.INFO,
@@ -51,6 +49,9 @@ class God:
             rowCount,
             loadExistingSave=False,
             saveData=None):
+        self._sexualReproductionDecisionNetwork = DecisionNetworkSexual()
+        self._asexualReproductionDecisionNetwork = DecisionNetworkAsexual()
+
         if not loadExistingSave:
             logging.info("Initializing new God object")
 
@@ -73,6 +74,9 @@ class God:
             # Initialize species managers
             self._speciesManagers = []
             for savedSpecies in saveData['_speciesManagers']:
+                decisionNetworkToUse = self._sexualReproductionDecisionNetwork \
+                                        if savedSpecies['_startingGenome'] == 'Sexual' \
+                                        else self._asexualReproductionDecisionNetwork
                 self._speciesManagers.append(
                     creatures.species_manager.SpeciesManager(
                         None,
@@ -80,6 +84,7 @@ class God:
                         self._simulationWidth,
                         self._simulationHeight,
                         self._environment,
+                        decisionNetworkToUse,
                         loadExistingSave=True,
                         saveData=savedSpecies))
 
@@ -128,12 +133,17 @@ class God:
     def createNewSpecies(self, speciesName, startingGenome):
         logging.info(f"Creating new species: {speciesName}")
 
+        decisionNetworkToUse = self._sexualReproductionDecisionNetwork \
+                                if startingGenome.reproductionType == ReproductionType.SEXUAL \
+                                else self._asexualReproductionDecisionNetwork
+
         newSpecies = creatures.species_manager.SpeciesManager(
             speciesName,
             startingGenome,
             self._simulationWidth,
             self._simulationHeight,
-            self._environment)
+            self._environment,
+            decisionNetworkToUse)
         self._speciesManagers.append(newSpecies)
 
     def deleteSpecies(self, speciesName):


### PR DESCRIPTION
Instead of each `Creature` object initializing a brand-new `DecisionNetwork` class, we will now have the `God` component create only a single instance of each distinct child class of the `DecisionNetwork`, and pass references to the correct network to the `Creature` objects for them all to access.