### PR TITLE
Navbar refresh

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -91,7 +91,6 @@ function App() {
             const res = response.data
             setCreatureList(res.creatureRegistry)
             setResourceList(res.resourceRegistry)
-            setTopographyInfo(res.topographyRegistry)
         })
     }
 
@@ -203,7 +202,6 @@ function App() {
                     startSimulationCallback={startSimulation}
                     ticksPerSecond={simulationTicksPerSecond}
                     hasSimulationStarted={hasSimulationStarted}
-                    topographyInfo={topographyInfo}
                     toggleTextSimulationCallback={showTextToggle}
                 />
 

--- a/frontend/src/SimulationNavBar/SimulationNavBar.js
+++ b/frontend/src/SimulationNavBar/SimulationNavBar.js
@@ -66,7 +66,6 @@ function SimulationNavBar({
                 show={showTopographyPage}
                 closeTopographyPage={closeTopographyPage}
                 showGridBorder={showGridBorder}
-                topographyInfo={topographyInfo}
             />
 
             <NewCreatureOrSpeciesForm

--- a/frontend/src/SimulationNavBar/Topography/Topography.js
+++ b/frontend/src/SimulationNavBar/Topography/Topography.js
@@ -10,7 +10,6 @@ function TopographyPage(props) {
     const [topography, setTopography] = useState('unselected')
     const [dragging, setDragging] = useState(false)
     const [position, setPosition] = useState({ x: 0, y: 160 })
-    const [isLoading, setLoading] = useState(true)
 
     /*async function getSimulationInfo() {
         await axios({

--- a/frontend/src/SimulationNavBar/Topography/Topography.js
+++ b/frontend/src/SimulationNavBar/Topography/Topography.js
@@ -4,10 +4,24 @@ import { useState, useEffect } from 'react'
 import { FaTimes, FaArrowsAlt } from 'react-icons/fa'
 import axios from 'axios'
 
+let topographyInfo = []
+
 function TopographyPage(props) {
     const [topography, setTopography] = useState('unselected')
     const [dragging, setDragging] = useState(false)
     const [position, setPosition] = useState({ x: 0, y: 160 })
+
+    async function getSimulationInfo() {
+        await axios({
+            method: 'GET',
+            url: 'http://localhost:5000/get-simulation-info',
+        }).then((response) => {
+            const res = response.data
+            topographyInfo = res.topographyRegistry
+        })
+    }
+
+    getSimulationInfo()
 
     const handleDragStart = (e) => {
         setDragging(true)
@@ -120,7 +134,7 @@ function Grid(props) {
 
     let jsx = []
 
-    console.log(props.topographyInfo)
+    console.log(topographyInfo)
 
     for (let i = 0; i < 1250; i++) {
         jsx.push(

--- a/frontend/src/SimulationNavBar/Topography/Topography.js
+++ b/frontend/src/SimulationNavBar/Topography/Topography.js
@@ -10,7 +10,7 @@ function TopographyPage(props) {
     const [topography, setTopography] = useState('unselected')
     const [dragging, setDragging] = useState(false)
     const [position, setPosition] = useState({ x: 0, y: 160 })
-    const [isLoading, setLoading] = useState(true);
+    const [isLoading, setLoading] = useState(true)
 
     /*async function getSimulationInfo() {
         await axios({
@@ -24,10 +24,12 @@ function TopographyPage(props) {
     }*/
 
     useEffect(() => {
-        axios.get("http://localhost:5000/get-simulation-info").then(response => {
-            topographyInfo = response.data.topographyRegistry
-        });
-      }, []);
+        axios
+            .get('http://localhost:5000/get-simulation-info')
+            .then((response) => {
+                topographyInfo = response.data.topographyRegistry
+            })
+    }, [])
 
     //do not attempt to load the grid or anything else until the topography data is gotten
     if (topographyInfo.length === 0) {

--- a/frontend/src/SimulationNavBar/Topography/Topography.js
+++ b/frontend/src/SimulationNavBar/Topography/Topography.js
@@ -26,11 +26,10 @@ function TopographyPage(props) {
     useEffect(() => {
         axios.get("http://localhost:5000/get-simulation-info").then(response => {
             topographyInfo = response.data.topographyRegistry
-            setLoading(false)
         });
       }, []);
 
-    if (isLoading) {
+    if (topographyInfo.length === 0) {
         return <></>
     }
 

--- a/frontend/src/SimulationNavBar/Topography/Topography.js
+++ b/frontend/src/SimulationNavBar/Topography/Topography.js
@@ -10,8 +10,9 @@ function TopographyPage(props) {
     const [topography, setTopography] = useState('unselected')
     const [dragging, setDragging] = useState(false)
     const [position, setPosition] = useState({ x: 0, y: 160 })
+    const [isLoading, setLoading] = useState(true);
 
-    async function getSimulationInfo() {
+    /*async function getSimulationInfo() {
         await axios({
             method: 'GET',
             url: 'http://localhost:5000/get-simulation-info',
@@ -19,9 +20,19 @@ function TopographyPage(props) {
             const res = response.data
             topographyInfo = res.topographyRegistry
         })
-    }
+        console.log("ran")
+    }*/
 
-    getSimulationInfo()
+    useEffect(() => {
+        axios.get("http://localhost:5000/get-simulation-info").then(response => {
+            topographyInfo = response.data.topographyRegistry
+            setLoading(false)
+        });
+      }, []);
+
+    if (isLoading) {
+        return <></>
+    }
 
     const handleDragStart = (e) => {
         setDragging(true)
@@ -50,7 +61,7 @@ function TopographyPage(props) {
                 <Grid
                     showGridBorder={props.showGridBorder}
                     selectTopography={topography}
-                    topographyInfo={props.topographyInfo}
+                    topographyInfo={topographyInfo}
                 />
 
                 <div
@@ -122,7 +133,7 @@ function TopographyPage(props) {
     } else {
         return (
             <Grid
-                topographyInfo={props.topographyInfo}
+                topographyInfo={topographyInfo}
                 showGridBorder={props.showGridBorder}
             />
         )
@@ -139,13 +150,13 @@ function Grid(props) {
     for (let i = 0; i < 1250; i++) {
         jsx.push(
             <Node
-                id={props.topographyInfo[i]}
+                id={topographyInfo[i]}
                 toggleSelected={toggleSelected}
-                topography={props.topographyInfo[i].type}
+                topography={topographyInfo[i].type}
                 selectTopography={props.selectTopography}
                 showGridBorder={props.showGridBorder}
-                row={props.topographyInfo[i].row}
-                col={props.topographyInfo[i].column}
+                row={topographyInfo[i].row}
+                col={topographyInfo[i].column}
             />
         )
     }
@@ -184,7 +195,7 @@ function Grid(props) {
 
     async function toggleSelected(row, col) {
         // find the index of the node that was clicked
-        let index = props.topographyInfo.findIndex(function (node) {
+        let index = topographyInfo.findIndex(function (node) {
             if (node.row === row && node.column === col) {
                 return true
             }
@@ -193,10 +204,10 @@ function Grid(props) {
         console.log(row, col)
 
         //if the topography is selected, update the coord, else flip it
-        if (props.topographyInfo[index].type != 'unselected') {
+        if (topographyInfo[index].type != 'unselected') {
             // This is what I had to do to actually change the visuals, unfortunately it wouldn't
             // automatically update after making the backend call
-            props.topographyInfo[index].type = 'unselected'
+            topographyInfo[index].type = 'unselected'
 
             // Delete topography in backend at (col, row) position
             await axios({
@@ -210,7 +221,7 @@ function Grid(props) {
         } else {
             // This is what I had to do to actually change the visuals, unfortunately it wouldn't
             // automatically update after making the backend call
-            props.topographyInfo[index].type = props.selectTopography
+            topographyInfo[index].type = props.selectTopography
 
             // Add new topography in backend at (col, row) position
             await axios({

--- a/frontend/src/SimulationNavBar/Topography/Topography.js
+++ b/frontend/src/SimulationNavBar/Topography/Topography.js
@@ -29,6 +29,7 @@ function TopographyPage(props) {
         });
       }, []);
 
+    //do not attempt to load the grid or anything else until the topography data is gotten
     if (topographyInfo.length === 0) {
         return <></>
     }


### PR DESCRIPTION
The first step towards stopping the navbar refresh ended up being to handle the topography data in the topography.js file.

App.js: On the front end app.js no longer receives and sends the topography data. There should probably be a new function specifically _for_ calling that data, that way it no longer gets sent with the resource and creature info.

SimulationNavBar.js: the topography data is no longer sent through from App.js to Topography.js.

Topography.js: The call to the backend is now made in this file, and only once at the creation. After that, all the data is stored in Topography.js.

